### PR TITLE
basic_consume $no_ack default true

### DIFF
--- a/libraries/Rabbitmq.php
+++ b/libraries/Rabbitmq.php
@@ -119,7 +119,7 @@ class Rabbitmq {
             $this->channel->basic_qos(null, 1, null);
 
             // Define consuming with 'process' callback
-            $this->channel->basic_consume($queue, '', false, false, false, false, $callback);
+            $this->channel->basic_consume($queue, '', false, true, false, false, $callback);
 
             // Continue the process of CLI command, waiting for others instructions
             while (count($this->channel->callbacks)) {


### PR DESCRIPTION
message not consume when $no_ack = false.
set $no_ack = true for consume.
